### PR TITLE
Disabled BARO and MINS selector for both pilots.

### DIFF
--- a/definitions/aircraft/PMDG Simulations - Boeing 737NG.yaml
+++ b/definitions/aircraft/PMDG Simulations - Boeing 737NG.yaml
@@ -2985,17 +2985,17 @@ shared:
 # - # OVHT/DET ANNUN
 #   type: var
 #   var_name: L:switch_354_73X
-  - # CPT Minimums (MINS) Selector (middle)
-    type: NumIncrement
-    var_name: L:switch_355_73X
-    var_units: Number
-    var_type: f64
-    up_event_name: ROTOR_BRAKE
-    up_event_param: 35502
-    down_event_name: ROTOR_BRAKE
-    down_event_param: 35501
-    increment_by: 1
-    use_calculator: true
+  # - # CPT Minimums (MINS) Selector (middle)
+  #   type: NumIncrement
+  #   var_name: L:switch_355_73X
+  #   var_units: Number
+  #   var_type: f64
+  #   up_event_name: ROTOR_BRAKE
+  #   up_event_param: 35502
+  #   down_event_name: ROTOR_BRAKE
+  #   down_event_param: 35501
+  #   increment_by: 1
+  #   use_calculator: true
   - # CPT Minimums (MINS) Reference Selector (outer)
     type: ToggleSwitch
     var_name: L:switch_356_73X
@@ -3098,15 +3098,15 @@ shared:
     event_param: 36601
     on_condition_value: 100
     use_calculator: true
-  - # CPT BAROMETRIC (BARO) SELECTOR (middle) and BAROMETRIC (BARO) STANDARD (STD) Switch (inner)
-    type: NumSet
-    var_name: L:switch_367_73X
-    var_units: Number
-    var_type: f64
-    multiply_by: -0.03
-    add_by: 36704
-    event_name: ROTOR_BRAKE
-    use_calculator: true
+  # - # CPT BAROMETRIC (BARO) SELECTOR (middle) and BAROMETRIC (BARO) STANDARD (STD) Switch (inner)
+  #   type: NumSet
+  #   var_name: L:switch_367_73X
+  #   var_units: Number
+  #   var_type: f64
+  #   multiply_by: -0.03
+  #   add_by: 36704
+  #   event_name: ROTOR_BRAKE
+  #   use_calculator: true
   - # CPT VOR2/ADF2 Switch
     type: NumIncrement
     var_name: L:switch_368_73X
@@ -3442,17 +3442,17 @@ shared:
   - # FO COURSE SELECTOR knob Collins/Honeywell (keep var)
     type: var
     var_name: L:switch_409_73X
-  - # FO Minimums (MINS) Selector (middle)
-    type: NumIncrement
-    var_name: L:switch_411_73X
-    var_units: Number
-    var_type: f64
-    up_event_name: ROTOR_BRAKE
-    up_event_param: 41102
-    down_event_name: ROTOR_BRAKE
-    down_event_param: 41101
-    increment_by: 1
-    use_calculator: true
+  # - # FO Minimums (MINS) Selector (middle)
+  #   type: NumIncrement
+  #   var_name: L:switch_411_73X
+  #   var_units: Number
+  #   var_type: f64
+  #   up_event_name: ROTOR_BRAKE
+  #   up_event_param: 41102
+  #   down_event_name: ROTOR_BRAKE
+  #   down_event_param: 41101
+  #   increment_by: 1
+  #   use_calculator: true
   - # FO Minimums (MINS) Reference Selector (outer)
     type: ToggleSwitch
     var_name: L:switch_412_73X
@@ -3555,15 +3555,15 @@ shared:
     event_param: 42201
     on_condition_value: 100
     use_calculator: true
-  - # FO BAROMETRIC (BARO) SELECTOR (middle) and BAROMETRIC (BARO) STANDARD (STD) Switch (inner)
-    type: NumSet
-    var_name: L:switch_423_73X
-    var_units: Number
-    var_type: f64
-    multiply_by: -0.03
-    add_by: 42304
-    event_name: ROTOR_BRAKE
-    use_calculator: true
+  # - # FO BAROMETRIC (BARO) SELECTOR (middle) and BAROMETRIC (BARO) STANDARD (STD) Switch (inner)
+  #   type: NumSet
+  #   var_name: L:switch_423_73X
+  #   var_units: Number
+  #   var_type: f64
+  #   multiply_by: -0.03
+  #   add_by: 42304
+  #   event_name: ROTOR_BRAKE
+  #   use_calculator: true
   - # FO VOR2/ADF2 Switch
     type: NumIncrement
     var_name: L:switch_424_73X


### PR DESCRIPTION
Each pilot has to set this value separately. This prevent descyned state of BARO and MINS setting but implies pressures and minimums to be set by both pilots manually (same as CRZ and LAND ALT)